### PR TITLE
TSK: Removal of wrong "PlayerCard" tags

### DIFF
--- a/campaigns/the_scarlet_keys.json
+++ b/campaigns/the_scarlet_keys.json
@@ -16735,9 +16735,6 @@
                         "g": 0.713235259,
                         "b": 0.713235259
                       },
-                      "Tags": [
-                        "PlayerCard"
-                      ],
                       "LayoutGroupSortIndex": 0,
                       "Value": 0,
                       "Locked": false,
@@ -16796,9 +16793,6 @@
                         "g": 0.713235259,
                         "b": 0.713235259
                       },
-                      "Tags": [
-                        "PlayerCard"
-                      ],
                       "LayoutGroupSortIndex": 0,
                       "Value": 0,
                       "Locked": false,
@@ -16857,9 +16851,6 @@
                         "g": 0.713235259,
                         "b": 0.713235259
                       },
-                      "Tags": [
-                        "PlayerCard"
-                      ],
                       "LayoutGroupSortIndex": 0,
                       "Value": 0,
                       "Locked": false,
@@ -16918,9 +16909,6 @@
                         "g": 0.713235259,
                         "b": 0.713235259
                       },
-                      "Tags": [
-                        "PlayerCard"
-                      ],
                       "LayoutGroupSortIndex": 0,
                       "Value": 0,
                       "Locked": false,
@@ -16979,9 +16967,6 @@
                         "g": 0.713235259,
                         "b": 0.713235259
                       },
-                      "Tags": [
-                        "PlayerCard"
-                      ],
                       "LayoutGroupSortIndex": 0,
                       "Value": 0,
                       "Locked": false,
@@ -17040,9 +17025,6 @@
                         "g": 0.713235259,
                         "b": 0.713235259
                       },
-                      "Tags": [
-                        "PlayerCard"
-                      ],
                       "LayoutGroupSortIndex": 0,
                       "Value": 0,
                       "Locked": false,
@@ -17817,9 +17799,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -17936,9 +17915,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -18287,9 +18263,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -18522,9 +18495,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -18583,9 +18553,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -18876,9 +18843,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -33881,9 +33845,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -41621,9 +41582,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -48021,9 +47979,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -57788,9 +57743,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -57849,9 +57801,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -57910,9 +57859,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -57971,9 +57917,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -58032,9 +57975,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -61520,9 +61460,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -61581,9 +61518,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -61642,9 +61576,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -61703,9 +61634,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -61764,9 +61692,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -61825,9 +61750,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,


### PR DESCRIPTION
Some encounter cards were falsely tagged as "PlayerCard" and thus got discarded to the local discard pile of the playmats.