### PR TITLE
Fortune and Folly: Correction of wrong "PlayerCard" tags

### DIFF
--- a/scenarios/fortune_and_folly.json
+++ b/scenarios/fortune_and_folly.json
@@ -1624,9 +1624,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -1695,9 +1692,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -1756,9 +1750,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -1817,9 +1808,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -1878,9 +1866,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -1939,9 +1924,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -2000,9 +1982,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -2061,9 +2040,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -2122,9 +2098,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -2183,9 +2156,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -2246,6 +2216,9 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
+              "Tags": [
+                "PlayerCard"
+              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -2304,9 +2277,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -3077,9 +3047,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -3152,9 +3119,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3213,9 +3177,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3274,9 +3235,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3335,9 +3293,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3396,9 +3351,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3457,9 +3409,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3518,9 +3467,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3579,9 +3525,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3640,9 +3583,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3701,9 +3641,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3762,9 +3699,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3823,9 +3757,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3884,9 +3815,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -3947,9 +3875,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -4013,9 +3938,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -4074,9 +3996,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -4135,9 +4054,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -4196,9 +4112,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -5491,6 +5404,9 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
+              "Tags": [
+                "PlayerCard"
+              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -5549,6 +5465,9 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
+              "Tags": [
+                "PlayerCard"
+              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -5607,6 +5526,9 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
+              "Tags": [
+                "PlayerCard"
+              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -5665,6 +5587,9 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
+              "Tags": [
+                "PlayerCard"
+              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -5956,9 +5881,6 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
-          "Tags": [
-            "PlayerCard"
-          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -6021,9 +5943,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6082,9 +6001,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6143,9 +6059,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6286,9 +6199,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6347,9 +6257,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6408,9 +6315,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6469,9 +6373,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6530,9 +6431,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6591,9 +6489,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6652,9 +6547,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6713,9 +6605,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6774,9 +6663,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6835,9 +6721,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6896,9 +6779,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -6957,9 +6837,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -7018,9 +6895,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -7079,9 +6953,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -7140,9 +7011,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -7201,9 +7069,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -7262,9 +7127,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -7323,9 +7185,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -7384,9 +7243,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -7445,9 +7301,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -7506,9 +7359,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -7569,6 +7419,9 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "PlayerCard"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -7742,9 +7595,6 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
-          "Tags": [
-            "PlayerCard"
-          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -8646,9 +8496,6 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
-          "Tags": [
-            "PlayerCard"
-          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -8711,9 +8558,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -8772,9 +8616,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -8833,9 +8674,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -9531,9 +9369,6 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
-          "Tags": [
-            "PlayerCard"
-          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -10242,9 +10077,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -10364,9 +10196,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -10435,9 +10264,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -10496,9 +10322,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -10557,9 +10380,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -10618,9 +10438,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -10679,9 +10496,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -10740,9 +10554,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -10801,9 +10612,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -10862,9 +10670,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -10923,9 +10728,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -10986,6 +10788,9 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
+              "Tags": [
+                "PlayerCard"
+              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -11400,9 +11205,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -11475,9 +11277,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -11536,9 +11335,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -11597,9 +11393,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -11658,9 +11451,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -11719,9 +11509,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -11780,9 +11567,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -11841,9 +11625,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -11902,9 +11683,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -11963,9 +11741,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -12024,9 +11799,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -12085,9 +11857,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -12146,9 +11915,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -12207,9 +11973,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -12270,9 +12033,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -12336,9 +12096,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -12397,9 +12154,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -12458,9 +12212,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -12519,9 +12270,6 @@
                     "g": 0.713235259,
                     "b": 0.713235259
                   },
-                  "Tags": [
-                    "PlayerCard"
-                  ],
                   "LayoutGroupSortIndex": 0,
                   "Value": 0,
                   "Locked": false,
@@ -13801,6 +13549,9 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
+              "Tags": [
+                "PlayerCard"
+              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -13859,6 +13610,9 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
+              "Tags": [
+                "PlayerCard"
+              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -13917,6 +13671,9 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
+              "Tags": [
+                "PlayerCard"
+              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -13975,6 +13732,9 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
+              "Tags": [
+                "PlayerCard"
+              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -14849,9 +14609,6 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
-          "Tags": [
-            "PlayerCard"
-          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,
@@ -14914,9 +14671,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -14975,9 +14729,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15036,9 +14787,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15176,9 +14924,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15237,9 +14982,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15298,9 +15040,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15359,9 +15098,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15420,9 +15156,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15481,9 +15214,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15542,9 +15272,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15603,9 +15330,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15664,9 +15388,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15725,9 +15446,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15786,9 +15504,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15847,9 +15562,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15908,9 +15620,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -15969,9 +15678,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -16030,9 +15736,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -16091,9 +15794,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -16152,9 +15852,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -16213,9 +15910,6 @@
                 "g": 0.713235259,
                 "b": 0.713235259
               },
-              "Tags": [
-                "PlayerCard"
-              ],
               "LayoutGroupSortIndex": 0,
               "Value": 0,
               "Locked": false,
@@ -16449,6 +16143,9 @@
             "g": 0.713235259,
             "b": 0.713235259
           },
+          "Tags": [
+            "PlayerCard"
+          ],
           "LayoutGroupSortIndex": 0,
           "Value": 0,
           "Locked": false,


### PR DESCRIPTION
I removed the tag from the encounter cards and added it for the cards that could actually be placed on a playermat.

Issue: https://github.com/argonui/SCED/issues/60